### PR TITLE
回滚reset-v1

### DIFF
--- a/Commit.java
+++ b/Commit.java
@@ -1,46 +1,73 @@
-package version_control;
 
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Stream;
 
-/**
- * @className: Commit
- * @description: class Commit designed for commits
+import src.overload;
+
+//commit value:
+//    1.根目录的hash
+//    2.上一次commit的key
+
+/* Sample
+commit 56fe26ad9101d8a15e2d1cb46417fbe38a9a9041 (HEAD -> tast_01_v3, origin/tast_01_v3)
+Author: 陆甄敏 <zhenmin0226@163.com>
+Date:   Wed Dec 9 14:33:01 2020 +0800
+
+    Change Blob1 to Blob
+
+commit 80abf20f197563ea14ca29f2d6b0945c483b2682
+Author: 陆甄敏 <zhenmin0226@163.com>
+Date:   Wed Dec 9 14:25:14 2020 +0800
+
+    修改Blob1
  */
 public class Commit extends KeyValueObject{
-    //文件路径
-    public String publicPath = "git";
-    public String pathOfObjects = publicPath + File.separator + "Objects";
-    public String pathOfHEAD = publicPath + File.separator + "HEAD"; //current HEAD
-    public String pathOfConfig = publicPath + File.separator + "Config"; //user info
-
-    //commit value
+    private static final Object[] String = null;
+	//数据域
     private String key;
     private String value;
     private String parent; //已有最新commit的key
-
     //public static HEAD myHEAD; //HEAD
     //public HEAD myHEAD; //HEAD
-    public String path = "objects";
-    public String pathOfHEAD = path + File.separator + "HEAD";
+    public static String path = "Objects";
+    public static String pathOfHEAD = path + File.separator + "HEAD"; //current HEAD
+    public static String pathOfConfig = path + File.separator + "Config"; //user info
     private String author;
     private String email;
     private String committer;
-    private java.util.Date dateCreated;
-    public static Log log;
+    private String dateCreated;
+    private String descOfCommit; //description of commit
 
 
     //函数
-    public Commit(String keyOfRoot) throws Exception {
+    public Commit(String keyOfRoot, String descOfCommit) throws Exception {
+        this.dateCreated = (new Date()).toString();
+        this.descOfCommit = descOfCommit;
+
+        //判断文件Config是否存在，存在则读取author，email；否则调用Config创建Config文件
+        if(!(new File(pathOfConfig).exists())) {
+            new Config();
+        }
+        this.author = getTargetValue("username", pathOfConfig); //在Config文件中，author对应的是username
+        this.email = getTargetValue("email", pathOfConfig);
+
+        //set commit value
         this.value = "";
         //通过是否存在HEAD文件来判断，是否是第一次commit
         //如果HEAD文件不存在，说明是第一次commit
         if(!((new File(pathOfHEAD)).exists())){
             //commit value是根目录的tree key
             this.value += "tree " + keyOfRoot + "\n";
+            this.value += "author " + author + "\n";
+            this.value += "email " + email + "\n";
+            this.value += "date " + dateCreated + "\n";
+            this.value += "description " + descOfCommit + "\n";
             //生成commit key
             this.key = generateKey(value);
             //生成HEAD()
@@ -50,103 +77,58 @@ public class Commit extends KeyValueObject{
         else { //commit value是根目录的tree key
             this.value += "tree " + keyOfRoot + "\n";
             this.value += "parent " + getParent() + "\n";
+            this.value += "author " + author + "\n";
+            this.value += "email " + email + "\n";
+            this.value += "date " + dateCreated + "\n";
+            this.value += "description " + descOfCommit + "\n";
             //生成commit key
             this.key = generateKey(value);
             //更新HEAD文件里的commit key
             //myHEAD.setValue(key);
             // 如果利用myHEAD对象来更新HEAD文件，程序运行结束之后myHEAD会被释放
             // 下一次运行程序的时候，并不会是第一次commit，就不会生成myHEAD对象了
-            // 此时，myHEAD=null，会报错！
+            // 此时，myHEAD=null，会报错
             new HEAD(key); //现在是在每次commit，都会产生HEAD对象
             //在HEAD构造方法里，如果不是第一次commit，会更新HEAD文件的value
-    private String author;
-    private String email;
-    private String dateCreated;
-    private String descOfCommit; //description of commit
-
-
-    /**
-     * @description 给定根目录的key和上一次commit的key，生成这一次commit的commit对象
-     * @param keyOfRoot
-     * @param descOfCommit
-     * @throws Exception
-     */
-    public Commit(String keyOfRoot, String descOfCommit) throws Exception {
-        this.dateCreated = (new Date()).toString();
-        this.descOfCommit = descOfCommit;
-
-        //判断文件Config是否存在，存在则读取author，email；否则调用Config创建Config文件
-        if(!(new File(pathOfConfig).exists())) {
-            new Config();
         }
-        this.author = Util.getTargetValue("username", pathOfConfig); //在Config文件中，author对应的是username
-        this.email = Util.getTargetValue("email", pathOfConfig);
 
-        //initial commit value
-        this.value = "";
-        //set commit value
-        this.value += "tree " + keyOfRoot + "\n";
-        if(((new File(pathOfHEAD)).exists())){ //通过是否存在HEAD文件来判断，是否是第一次commit
-            //如果HEAD文件存在，说明是不是第一次commit，则commit value要加入parent commit key
-            this.value += "parent " + getParent() + "\n";
-        }
-        this.value += "author " + author + "\n";
-        this.value += "email " + email + "\n";
-        this.value += "date " + dateCreated + "\n";
-        this.value += "description " + descOfCommit + "\n";
-
-        //生成commit key
-        this.key = generateKey(value);
-        //生成HEAD()
-        new HEAD(key); //在HEAD构造方法例，如果是第一次commit，会产生HEAD文件，并存入value
         //生成commit的key-value文件
-        Util.generateFile(pathOfObjects, key);
+        generateFile(key);
         //向commit的key-value文件中写入value，value为tree key
-
         putValueIntoFile(key, value);
-        dateCreated=new java.util.Date();
-        new Log(key);//生成commit的同时，补充logs文件
+        String logcontent="commit: "+key+"\n"+"author " + author + "\n"+"date " + dateCreated + "\n"+descOfCommit+"\n";
+        new Log(logcontent);//生成commit的同时，补充logs文件
     }
     //获得已有最新commit key
-
-        Util.putValueIntoFile(pathOfObjects, key, value);
-    }
-
-    /**
-     * @description 获得已有最新commit key
-     * @return
-     * @throws IOException
-     */
-
     public String getParent() throws IOException {
         this.parent = Files.readString(Paths.get(pathOfHEAD)); //从HEAD中获得上一次commit的key
         return parent;
     }
 
-    //返回parent commit key
     public String returnParent(){
         return parent;
     }
 
-    //返回commit key
     public String returnKey(){
         return key;
     }
 
-    //返回commit value
     public String returnValue(){
         return value;
     }
 
 
-
     public static String getTargetValue(String target, String path){
         String targetValue = "";
         try {
-            String contentOfFile = Files.readString(Paths.get(path));
-            int index = contentOfFile.indexOf(target);
-            System.out.println(index);
-            targetValue = contentOfFile.substring(index + target.length() + 1, index + target.length() + 1 + 40);
+            FileReader fileReader = new FileReader(path);
+            BufferedReader in = new BufferedReader(fileReader);
+            do{
+                String line = in.readLine();
+                if(line.matches(target + ".*")) {
+                    targetValue = line.substring(target.length() + 1).trim();
+                }
+            }while(targetValue == "");
         }
         catch(FileNotFoundException ex){
             System.out.println("No such file -- " + (new File(path)).getName());
@@ -159,15 +141,12 @@ public class Commit extends KeyValueObject{
         return targetValue;
     }
 
-
-
     @Override
     public String toString(){
         //返回commit到下面的格式
         return "commit " + key + "\n"
                 + "parent " + parent + "\n"
                 + "author " + author + "<" + email + ">" + "\n"
-
                 + "date " + dateCreated + "\n";
 /*   commit 80abf20f197563ea14ca29f2d6b0945c483b2682
      parent 80abf20f197563ea14ca29f2d6b0945c483b2682
@@ -175,49 +154,87 @@ public class Commit extends KeyValueObject{
      date dateCreated
 */
     }
-    //回滚函数：给定希望回滚到的commit，
-    //1.找到commit中tree的内容，
-    //2.在工作路径中还原commit中的文件，这里是将commit中所有文件替换掉原始的文件夹，还没有考虑只更换差异文件的优化方式。
-    //3.更新HEAD文件和logs文件
+    /*回滚函数：给定希望回滚到的commit，
+    1.找到commit中tree的内容，
+    2.在工作路径中还原commit中的文件，首先判断工作路径中是否有想还原中没有的文件，有的话就删掉；
+    然后逐行读取tree中文件的hash值，还原时首先与现有文件名比较，若名字相同，则比较文件内容，文件内容相同，文件保留，不同则删除现有的
+    增加需要还原的。若文件名与现存工作区的不同，则直接补充上。
+   3.更新HEAD文件和logs文件
+   */
     public static void reset(String commitkey,String originpath)throws Exception {
-    	String keyoftree=getTargetValue("tree","Objects"+"/"+commitkey);
-    	writeback(keyoftree,originpath);
-    	new HEAD(commitkey);
-    	Log.deletecommit(commitkey);
+    	String keyoftree=getTargetValue("tree","Objects"+ File.separator +commitkey);//得到tree的哈希值
+    	writeback(keyoftree,originpath);//调用辅助函数负责还原文件
+    	new HEAD(commitkey);//更新HEAD指针
+    	Log.changelog(commitkey);//更新log文件，删除需要回滚的commit后面的commit
     }
-    	
+    
+    public static void reset(String commitkey)throws Exception {
+    	String keyoftree=getTargetValue("tree","Objects"+ File.separator +commitkey);//得到tree的哈希值
+    	String originpath="/Users/mayining/Desktop/test";
+    	writeback(keyoftree,originpath);//调用辅助函数负责还原文件
+    	new HEAD(commitkey);//更新HEAD指针
+    	Log.changelog(commitkey);//更新log文件，删除需要回滚的commit后面的commit
+    }
+    	/*
+    	 写回函数负责根据提供的tree的哈希值逐行扫描内容，如果是文件，则与工作区文件比较，再进行还原，如果是文件夹，则递归调用
+    	 函数进行内部文件的比较还原。
+    	 */
     public static void writeback(String key,String originpath)throws Exception{
     	File file = new File("Objects",key);
 		InputStreamReader inputReader = new InputStreamReader(new FileInputStream(file));
 		BufferedReader bf = new BufferedReader(inputReader);
-		// 按行读取字符串
-		String str;
-		while ((str = bf.readLine()) != null) {
-			if(str.startsWith("100644 blob ")) {//如果读入的hash是文件，则直接以覆盖的形式写入文件
-				String keyofblob=str.substring(12, 52);
-				String filename=str.substring(53,str.length());
-				String contentOfFile = Files.readString(Paths.get("Objects"+"/"+keyofblob));
-				File fl = new File(originpath+"/"+filename);
-	            FileWriter os = new FileWriter(fl);
-	            os.write(contentOfFile);
-	            os.flush();
-	            os.close();
+		// 将文件内容全部读取到str字符串中
+		String str="";
+		String strr="";
+		strr=bf.readLine();
+		while(strr!=null) {
+    		str+=strr+"\n";  
+    		strr=bf.readLine();
+    	}
+		//首先比较工作区文件夹中的文件是否在需要还原的tree里，如果不在，则删除
+		deletenonexisting(str,originpath);
+		//逐行读取str中内容
+		String []ss=str.split("\n");
+		for (int i=0;i<ss.length;i++){
+			if(ss[i].startsWith("100644 blob ")) {//如果读入的hash是文件，则首先得到文件的哈希值，文件名和文件内容
+				String keyofblob=ss[i].substring(12, 52);
+				String filename=ss[i].substring(53,ss[i].length());
+				String contentOfFile = Files.readString(Paths.get("Objects"+ File.separator +keyofblob));
+				File fl = new File(originpath+ File.separator +filename);
+				if(fl.exists()) {//与工作区文件比较，如果名称相同则进一步比较内容
+					String origincontent=Files.readString(Paths.get(originpath+ File.separator +filename));
+					if(contentOfFile.equals(origincontent)) {
+						return;//内容相同，文件不做处理，直接返回
+					}
+					else {
+			            FileWriter os = new FileWriter(fl);
+			            os.write(contentOfFile);
+			            os.flush();
+			            os.close();//文件内容不同，覆盖写入文件
 			}
-			if(str.startsWith("040000 tree ")) {
-				//如果读入的hash是文件夹，则
-				//首先删除工作目录的该文件夹，
-				//再创建新的文件夹
-				//递归文件夹中内容，直到所有文件都写入
-				String keyofnexttree=str.substring(12,52);
-				String dicname=str.substring(53,str.length());
-				File dic = new File(originpath+"/"+dicname);
-				if (dic.exists()) {
-					deletefiles(originpath+"/"+dicname);
 				}
-				Path path = Paths.get(originpath+"/"+dicname);
-				Path pathCreate = Files.createDirectory(path);
+			   else {
+					FileWriter os = new FileWriter(fl);
+		            os.write(contentOfFile);
+		            os.flush();
+		            os.close();//文件不存在，直接写入文件
+				}
+			}
+				
+			if(ss[i].startsWith("040000 tree ")) {
+				//如果读入的hash是文件夹，则
+				//比较文件夹是否存在，不存在则创建文件夹，存在则直接进入，比较里面内容
+				//递归文件夹中内容，直到所有文件都写入
+				String keyofnexttree=ss[i].substring(12,52);
+				String dicname=ss[i].substring(53,ss[i].length());
+				File dic = new File(originpath+ File.separator +dicname);
+				if (!dic.exists()) {
+					//deletefiles(originpath+ File.separator +dicname);
+					Path path = Paths.get(originpath+ File.separator +dicname);
+					Path pathCreate = Files.createDirectory(path);//文件夹不存在，创建文件夹
+				}
 				key=keyofnexttree;//更新递归的下一层key
-				originpath=originpath+"/"+dicname;//更新路径
+				originpath=originpath+ File.separator +dicname;//更新路径
 				writeback(key,originpath);
 				
 			}
@@ -226,6 +243,22 @@ public class Commit extends KeyValueObject{
 		inputReader.close();
 		bf.close();
     }
+    /*
+     删除不需要的文件函数
+     将文件夹中包含的file用listfiles函数展示出来，再检查每个文件的名称是否出现在tree的value中，如果
+     出现了，则不做处理，如果不存在，说明还原时不需要这个文件，则删除。
+     */
+    public static void deletenonexisting(String value,String path) throws IOException {
+    	File current=new File(path);
+    	File[] fs = current.listFiles();
+        for(int i=0;i<fs.length;i++) {
+        	String filename=fs[i].getName();
+        	if(!value.contains(filename)) {
+        		deletefiles(fs[i]);
+        	}
+        }
+    }
+    
     //递归删除文件夹
 	public static boolean deletefiles(String path) {
 		File file= new File(path);
@@ -241,6 +274,23 @@ public class Commit extends KeyValueObject{
 				}
 		return file.delete();
 		}
+	
+	@overload
+	public static boolean deletefiles(File file) {
+		if (!file.exists()) {
+			System.out.println("file does not exist");
+			return false;
+			}
+		if (file.isFile()) {
+			return file.delete();
+			} else {
+				for (File f : file.listFiles()) {
+					deletefiles(path+File.separator + f.getName());
+					}
+				}
+		return file.delete();
+		}
+	
 }
     	
     	
@@ -251,9 +301,3 @@ public class Commit extends KeyValueObject{
     	
     	
     
-
-                + "date " + dateCreated + "\n"
-                + "description " + descOfCommit;
-    }
-}
-

--- a/Log.java
+++ b/Log.java
@@ -1,43 +1,75 @@
-package version_control;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public class Log {
-	private static String value; //record every commit
     public static String path = "logs";//存放log文件的路径：目前没有考虑branch情况，所以只有一个文件
     
     public Log(String commit) throws Exception{
-    	if(!((new File(path)).exists())){
+    	if(!new File(path).exists()) {
+    		File file=new File(path);
+    		file.mkdir();
+    	}
+    	String head=Files.readString(Paths.get("objects"+ File.separator+"HEAD1"));
+    	String branchname=head.substring(head.lastIndexOf("/")+1);
+    	if(!((new File(path+File.separator+branchname)).exists())){
             (new File(path)).createNewFile();
-            this.value = commit;
-            putValueIntoFile(value);//第一次commit时，建立文件并把commit的key存入
+            putValueIntoFile(commit,path+File.separator+branchname);//第一次commit时，建立文件并把commit的key存入
     	}
     	else {
-    		addValueIntoFile(commit);//将后来的commit的key添加到logs文件中
- 
+    		putValueIntoFile(commit,path+File.separator+branchname);
     	}
-    	
-    }
-    public String showlogs() {
-    	return this.value;//显示value
     }
     
-    //在回滚之后删除logs中指定回滚之后的commit的key
-    public static String deletecommit(String targetcommit)throws Exception {
-    	value=Files.readString(Paths.get(path));
-    	int index = value.indexOf(targetcommit);
-    	value=value.substring(0,index+40);//截取指定commit之前部分的子串
-    	putValueIntoFile(value);
-    	return value;
+    /*在回滚之后修改logs对应文件中内容为目标commit的呢绒
+      只保存commit的key并读取commit文件中除了tree和parent部分的内容
+      读到目标commit时则停止循环，直接再向下读取三行的内容后关闭bufferreader和filereader停止读入
+     */
+    
+    public static void changelog(String targetcommit)throws Exception{
+    	String head=Files.readString(Paths.get("objects"+ File.separator+"HEAD1"));
+    	String branchname=head.substring(head.lastIndexOf("/")+1);
+    	FileReader fileReader = new FileReader("objects"+File.separator+targetcommit);
+        BufferedReader in = new BufferedReader(fileReader);
+        String line = in.readLine();
+        String value="commit "+targetcommit+"\n";
+        while(line!=null) {
+        		if(!line.startsWith("tree")&&(!line.startsWith("parent"))) {
+		        	value+=line+"\n";
+        		}
+		        line=in.readLine();
+        }
+        in.close();
+    	fileReader.close();
+    	putValueIntoFile(value,path+File.separator+branchname);
     }
     //新建文件并写入
-	public static void putValueIntoFile(String commit){ //把commit key放入logs文件
+    public static void showlogs() throws Exception {
+    	String curcommit=Files.readString(Paths.get("objects"+ File.separator+"HEAD"));
+        String content="";
+ 	    while(!curcommit.equals("")) {
+ 	    	content+="commit "+curcommit+"\n";
+        	content+="author "+Commit.getTargetValue("author", "objects"+ File.separator+curcommit)+"\n";
+        	content+="date "+Commit.getTargetValue("date", "objects"+ File.separator+curcommit)+"\n";
+        	content+=Commit.getTargetValue("description","objects"+ File.separator+curcommit)+"\r\n";
+        	String value=Files.readString(Paths.get("objects"+ File.separator+curcommit));
+        	if(value.contains("parent")) {
+        		String nextcommit=Commit.getTargetValue("parent","objects"+ File.separator+curcommit);
+        		curcommit=nextcommit;
+        	}
+        	else curcommit="";
+ 	    }
+    	System.out.println(content);
+    }
+	
+	public static void putValueIntoFile(String commit,String logpath){ //把commit key放入logs文件
         try {
-            File file = new File(path);
+            File file = new File(logpath);
             FileWriter os = new FileWriter(file);
             os.write(commit+"\r\n");
             os.flush();
@@ -46,18 +78,7 @@ public class Log {
             ex.printStackTrace();
         }
     }
-	
-	//以补充的方式写入
-	public void addValueIntoFile(String commit){ //把commit key放入logs文件
-        try {
-            File file = new File(path);
-            FileWriter os = new FileWriter(file,true);
-            os.write(commit+"\r\n");
-            os.flush();
-            os.close();
-        } catch (IOException ex) {
-            ex.printStackTrace();
-	
-        }
+	public static void main(String[] args) throws Exception {
+		showlogs();
 	}
 }

--- a/Log.java
+++ b/Log.java
@@ -1,0 +1,63 @@
+package version_control;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class Log {
+	private static String value; //record every commit
+    public static String path = "logs";//存放log文件的路径：目前没有考虑branch情况，所以只有一个文件
+    
+    public Log(String commit) throws Exception{
+    	if(!((new File(path)).exists())){
+            (new File(path)).createNewFile();
+            this.value = commit;
+            putValueIntoFile(value);//第一次commit时，建立文件并把commit的key存入
+    	}
+    	else {
+    		addValueIntoFile(commit);//将后来的commit的key添加到logs文件中
+ 
+    	}
+    	
+    }
+    public String showlogs() {
+    	return this.value;//显示value
+    }
+    
+    //在回滚之后删除logs中指定回滚之后的commit的key
+    public static String deletecommit(String targetcommit)throws Exception {
+    	value=Files.readString(Paths.get(path));
+    	int index = value.indexOf(targetcommit);
+    	value=value.substring(0,index+40);//截取指定commit之前部分的子串
+    	putValueIntoFile(value);
+    	return value;
+    }
+    //新建文件并写入
+	public static void putValueIntoFile(String commit){ //把commit key放入logs文件
+        try {
+            File file = new File(path);
+            FileWriter os = new FileWriter(file);
+            os.write(commit+"\r\n");
+            os.flush();
+            os.close();
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+	
+	//以补充的方式写入
+	public void addValueIntoFile(String commit){ //把commit key放入logs文件
+        try {
+            File file = new File(path);
+            FileWriter os = new FileWriter(file,true);
+            os.write(commit+"\r\n");
+            os.flush();
+            os.close();
+        } catch (IOException ex) {
+            ex.printStackTrace();
+	
+        }
+	}
+}

--- a/testreset.java
+++ b/testreset.java
@@ -1,0 +1,122 @@
+package version_control;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Scanner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.After;
+import org.junit.Assert;
+
+public class testreset {
+	@Before
+	public void show()throws Exception{
+		System.out.println(Files.readString(Paths.get("logs")));
+	}
+	
+	
+	@Test
+	public void testreset() throws Exception{
+		Scanner input=new Scanner(System.in);
+		String targetcommit=input.next();//读取输入返回的commit
+		Commit.reset(targetcommit,"/Users/mayining/Desktop/test");
+	}
+	
+	public static boolean deletefiles(String path) {
+		File file= new File(path);
+		if (!file.exists()) {
+			return false;
+			}
+		if (file.isFile()) {
+			return file.delete();
+			} else {
+				for (File f : file.listFiles()) {
+					deletefiles(path+File.separator + f.getName());
+					}
+				}
+		return file.delete();
+		}
+	
+	@After
+	public void show2()throws Exception{
+		System.out.println("删除后"+Files.readString(Paths.get("logs")));
+	}
+	
+	//根据关键字找寻上次提交中tree的哈希值函数
+	public String getTargetValue(String target, String path){
+        String targetValue = "";
+        try {
+            String contentOfFile = Files.readString(Paths.get(path));
+            int index = contentOfFile.indexOf(target);
+            targetValue = contentOfFile.substring(index + target.length() + 1, index + target.length() + 1 + 40);
+        }
+        catch(FileNotFoundException ex){
+            System.out.println("No such file -- " + (new File(path)).getName());
+            ex.getStackTrace();
+        }
+        catch(IOException ex){
+            System.out.println("Target value \"" + target + "\" not found");
+            ex.getStackTrace();
+        }
+        return targetValue;
+    }
+    
+	public void reset(String commitkey,String originpath)throws Exception {
+    	String keyoftree=getTargetValue("tree","Objects"+"/"+commitkey);
+    	System.out.println(keyoftree);
+    	writeback(keyoftree,originpath);
+    	new HEAD(commitkey);
+	}
+	
+	public void writeback(String key,String originpath)throws Exception{
+    	File file = new File("Objects",key);
+		InputStreamReader inputReader = new InputStreamReader(new FileInputStream(file));
+		BufferedReader bf = new BufferedReader(inputReader);
+		// 按行读取字符串
+		String str;
+		while ((str = bf.readLine()) != null) {
+			if(str.startsWith("100644 blob ")) {
+				
+	            //targetValue = contentOfFile.substring(12, 52);
+				String keyofblob=str.substring(12, 52);
+				String filename=str.substring(53,str.length());
+				String contentOfFile = Files.readString(Paths.get("Objects"+"/"+keyofblob));
+				File fl = new File(originpath+"/"+filename);
+	            FileWriter os = new FileWriter(fl);
+	            os.write(contentOfFile);
+	            os.flush();
+	            os.close();
+			}
+			if(str.startsWith("040000 tree ")) {
+				String keyofnexttree=str.substring(12,52);
+				String dicname=str.substring(53,str.length());
+				//String keyofnexttree=str.substring("040000 tree ".length(),  "040000 tree ".length() + 1 + 40);
+				//String dicname=str.substring("040000 tree ".length() + 1 + 40,str.length()-1);
+				File dic = new File(originpath+"/"+dicname);
+				if (dic.exists()) {
+					deletefiles(originpath+"/"+dicname);
+				}
+				Path path = Paths.get(originpath+"/"+dicname);
+				Path pathCreate = Files.createDirectory(path);
+				key=keyofnexttree;
+				System.out.println(key);
+				originpath=originpath+"/"+dicname;
+				writeback(key,originpath);
+			}
+		}
+		
+		inputReader.close();
+		bf.close();
+    }
+}
+
+


### PR DESCRIPTION
回滚设计文档：
1.新建logs类
-数据域：value，path
-方法：
-构造方法：第一次直接生成logs文件并存入commit的key；接下来的commit的key以补充形式写入
-展示value
-删除commit：在完成回滚后删除指定commit之后的commit的key
-创建新文件写入方法
-补充写入方法

2.补充commit方法
-在构造方法中补充构造logs文件的方法
-补充reset方法，实现以下步骤：
1.找到commit中tree的内容
2.在工作路径中还原commit中的文件，这里是将commit中所有文件替换掉原始的文件夹，还没有考虑只更换差异文件的优化方式。
3.更新HEAD文件
4.删除logs文件中指定commit之后的commit的信息

可能优化：1.在不同branch情况下logs应该是文件夹，2.logs存放的内容除了key还应该有内容之类的，3.这次好像并没有用到Log类的实例，只是用了方法。4.可以通过比较tree，blob的哈希值保留没有修改的文件，只替换修改了的。